### PR TITLE
Fix: getGridDensity using NanoVDB

### DIFF
--- a/src/homogeneous_medium.cpp
+++ b/src/homogeneous_medium.cpp
@@ -30,18 +30,16 @@ public:
         float t = std::max(0.0f, nearT);
         float tMax = std::min(mRec.tMax, farT);
         Color3f tr{1.0f};
-        float curr_density;
         float densityDivSigmaT = m_inv_max_density / m_sigma_t.maxCoeff();
 
         while (true) {
-            t += -log(1.0f - sampler->next1D()) * densityDivSigmaT;
+            t -= log(1.0f - sampler->next1D()) * densityDivSigmaT;
 
             if (t >= tMax) {
                 break;
             }
                 
-            curr_density = getDensity(ray(t));
-            tr *= 1.0f - std::max(0.0f, curr_density * m_inv_max_density);
+            tr *= 1.0f - std::max(0.0f, getDensity(ray(t)) * m_inv_max_density);
         }
         
         return tr;
@@ -67,7 +65,7 @@ public:
         float densityDivSigmaT = m_inv_max_density / m_sigma_t.maxCoeff();
 
         while (true) {
-            t += -log(1.0f - sampler->next1D()) * densityDivSigmaT;
+            t -= log(1.0f - sampler->next1D()) * densityDivSigmaT;
 
             if (t >= tMax) {
                 mRec.hasInteraction = false;


### PR DESCRIPTION
- GridDensity lookup now uses NanaoVDB, no longer using Hashmap
  - this eliminates the preprocessing time

@ETHenzlere can you please test if this actually works also for you 😄 Please render the `Medium/cbox_hetero-grid.xml` scene, and check that it renders the cloud. Thanks